### PR TITLE
PERF/BUG: Improve performance; prevent return-stream mutation

### DIFF
--- a/empyrical/stats.py
+++ b/empyrical/stats.py
@@ -417,7 +417,10 @@ def sharpe_ratio(returns, risk_free=0, period=DAILY, annualization=None):
 
     ann_factor = annualization_factor(period, annualization)
 
-    returns_risk_adj = returns - risk_free
+    if not (isinstance(risk_free, (float, int)) and risk_free == 0):
+        returns_risk_adj = returns - risk_free
+    else:
+        returns_risk_adj = returns
 
     if np.std(returns_risk_adj, ddof=1) == 0:
         return np.nan
@@ -471,7 +474,13 @@ def sortino_ratio(returns, required_return=0, period=DAILY,
     if len(returns) < 2:
         return np.nan
 
-    mu = nanmean(returns - required_return, axis=0)
+    if not (isinstance(required_return, (float, int))
+            and required_return == 0.0):
+        adj_returns = returns - required_return
+    else:
+        adj_returns = returns
+
+    mu = nanmean(adj_returns, axis=0)
     dsr = (_downside_risk if _downside_risk is not None
            else downside_risk(returns, required_return))
     sortino = mu / dsr
@@ -519,7 +528,12 @@ def downside_risk(returns, required_return=0, period=DAILY,
 
     ann_factor = annualization_factor(period, annualization)
 
-    downside_diff = returns - required_return
+    if not (isinstance(required_return, (float, int))
+            and required_return == 0.0):
+        downside_diff = returns - required_return
+    else:
+        downside_diff = returns
+
     mask = downside_diff > 0
     downside_diff[mask] = 0.0
     squares = np.square(downside_diff)

--- a/empyrical/stats.py
+++ b/empyrical/stats.py
@@ -596,12 +596,13 @@ def alpha_beta(returns, factor_returns, risk_free=0.0, period=DAILY,
 
     """
     b = beta(returns, factor_returns, risk_free)
-    a = alpha(returns, factor_returns, risk_free, period, annualization)
+    a = alpha(returns, factor_returns, risk_free, period, annualization,
+              _beta=b)
     return a, b
 
 
 def alpha(returns, factor_returns, risk_free=0.0, period=DAILY,
-          annualization=None):
+          annualization=None, _beta=None):
     """Calculates annualized alpha.
 
     Parameters
@@ -628,6 +629,9 @@ def alpha(returns, factor_returns, risk_free=0.0, period=DAILY,
         returns into annual returns. Value should be the annual frequency of
         `returns`.
         - See full explanation in :func:`~empyrical.stats.annual_return`.
+    _beta : float, optional
+        The beta for the given inputs, if already known. Will be calculated
+        internally if not provided.
 
     Returns
     -------
@@ -637,7 +641,11 @@ def alpha(returns, factor_returns, risk_free=0.0, period=DAILY,
     if len(returns) < 2:
         return np.nan
     ann_factor = annualization_factor(period, annualization)
-    b = beta(returns, factor_returns, risk_free)
+    if _beta is None:
+        b = beta(returns, factor_returns, risk_free)
+    else:
+        b = _beta
+
     alpha = returns - risk_free - b*(factor_returns - risk_free)
     return alpha.mean() * ann_factor
 

--- a/empyrical/stats.py
+++ b/empyrical/stats.py
@@ -43,8 +43,8 @@ ANNUALIZATION_FACTORS = {
 
 def _adjust_returns(returns, adjustment_factor):
     """
-    Adjusts the given returns by the given factor iff adjustment_factor is
-    non-zero
+    Returns a new pd.Series adjusted by adjustment_factor. Optimizes for the
+    case of adjustment_factor being 0
 
     Parameters
     ----------
@@ -56,7 +56,7 @@ def _adjust_returns(returns, adjustment_factor):
     pd.Series
     """
     if isinstance(adjustment_factor, (float, int)) and adjustment_factor == 0:
-        return returns
+        return returns.copy()
     return returns - adjustment_factor
 
 
@@ -138,6 +138,7 @@ def cum_returns(returns, starting_value=0):
         return np.nan
 
     if pd.isnull(returns.iloc[0]):
+        returns = returns.copy()
         returns.iloc[0] = 0.
 
     df_cum = np.exp(np.log1p(returns).cumsum())

--- a/empyrical/stats.py
+++ b/empyrical/stats.py
@@ -686,10 +686,16 @@ def beta(returns, factor_returns, risk_free=0.0):
     if len(indices) < 2:
         return np.nan
 
-    covar = np.cov(returns[indices]-risk_free,
-                   factor_returns[indices], ddof=0)[0][1]
+    if isinstance(risk_free, (float, int)) and risk_free == 0.0:
+        adj_returns = returns[indices]
+    else:
+        adj_returns = returns[indices] - risk_free
 
-    return covar/np.var(factor_returns[indices])
+    indexed_factor_returns = factor_returns[indices]
+
+    covar = np.cov(adj_returns, indexed_factor_returns, ddof=0)[0][1]
+
+    return covar/np.var(indexed_factor_returns)
 
 
 def stability_of_timeseries(returns):

--- a/empyrical/stats.py
+++ b/empyrical/stats.py
@@ -741,6 +741,8 @@ def stability_of_timeseries(returns):
     if len(returns) < 2:
         return np.nan
 
+    returns = returns.dropna()
+
     cum_log_returns = np.log1p(returns).cumsum()
     rhat = stats.linregress(np.arange(len(cum_log_returns)),
                             cum_log_returns.values)[2]

--- a/empyrical/stats.py
+++ b/empyrical/stats.py
@@ -645,14 +645,24 @@ def alpha(returns, factor_returns, risk_free=0.0, period=DAILY,
     """
     if len(returns) < 2:
         return np.nan
+
     ann_factor = annualization_factor(period, annualization)
+
     if _beta is None:
         b = beta(returns, factor_returns, risk_free)
     else:
         b = _beta
 
-    alpha = returns - risk_free - b*(factor_returns - risk_free)
-    return alpha.mean() * ann_factor
+    if isinstance(risk_free, (float, int)) and risk_free == 0.0:
+        adj_returns = returns
+        adj_factor_returns = factor_returns
+    else:
+        adj_returns = returns - risk_free
+        adj_factor_returns = factor_returns - risk_free
+
+    alpha_series = adj_returns - (b * adj_factor_returns)
+
+    return alpha_series.mean() * ann_factor
 
 
 def beta(returns, factor_returns, risk_free=0.0):

--- a/empyrical/stats.py
+++ b/empyrical/stats.py
@@ -437,7 +437,7 @@ def sharpe_ratio(returns, risk_free=0, period=DAILY, annualization=None):
 
     ann_factor = annualization_factor(period, annualization)
 
-    returns_risk_adj = _adjust_returns(returns, risk_free)
+    returns_risk_adj = _adjust_returns(returns, risk_free).dropna()
 
     if np.std(returns_risk_adj, ddof=1) == 0:
         return np.nan
@@ -769,6 +769,11 @@ def tail_ratio(returns):
 
     """
 
+    if len(returns) < 1:
+        return np.nan
+
+    # Be tolerant of nan's
+    returns = returns.dropna()
     if len(returns) < 1:
         return np.nan
 

--- a/empyrical/stats.py
+++ b/empyrical/stats.py
@@ -427,7 +427,7 @@ def sharpe_ratio(returns, risk_free=0, period=DAILY, annualization=None):
 
 
 def sortino_ratio(returns, required_return=0, period=DAILY,
-                  annualization=None):
+                  annualization=None, _downside_risk=None):
     """
     Determines the Sortino ratio of a strategy.
 
@@ -449,6 +449,9 @@ def sortino_ratio(returns, required_return=0, period=DAILY,
         Used to suppress default values available in `period` to convert
         returns into annual returns. Value should be the annual frequency of
         `returns`.
+    _downside_risk : float, optional
+        The downside risk of the given inputs, if known. Will be calculated if
+        not provided.
 
     Returns
     -------
@@ -469,7 +472,9 @@ def sortino_ratio(returns, required_return=0, period=DAILY,
         return np.nan
 
     mu = nanmean(returns - required_return, axis=0)
-    sortino = mu / downside_risk(returns, required_return)
+    dsr = (_downside_risk if _downside_risk is not None
+           else downside_risk(returns, required_return))
+    sortino = mu / dsr
     if len(returns.shape) == 2:
         sortino = pd.Series(sortino, index=returns.columns)
     return sortino * ann_factor

--- a/empyrical/tests/test_stats.py
+++ b/empyrical/tests/test_stats.py
@@ -232,7 +232,7 @@ class TestStats(TestCase):
 
     @parameterized.expand([
         (simple_benchmark, empyrical.DAILY, 0.0),
-        (mixed_returns, empyrical.DAILY, 0.8552777326693359),
+        (mixed_returns, empyrical.DAILY, 0.9136465399704637),
         (weekly_returns, empyrical.WEEKLY, 0.38851569394870583),
         (monthly_returns, empyrical.MONTHLY, 0.18663690238892558)
     ])
@@ -266,9 +266,9 @@ class TestStats(TestCase):
     @parameterized.expand([
         (empty_returns, 0.0, 0.0, np.nan),
         (one_return, 0.0, 0.0, np.nan),
-        (mixed_returns, 0.0, 10.0, 0.78629772289706013),
+        (mixed_returns, 0.0, 10.0, 0.83354263497557934),
         (mixed_returns, 0.0, -10.0, np.nan),
-        (mixed_returns, simple_benchmark, 0.0, 0.76470588235294112),
+        (mixed_returns, simple_benchmark, 0.0, 0.8125),
         (positive_returns, 0.01, 0.0, np.nan),
         (positive_returns, 0.011, 0.0, 1.125),
         (positive_returns, 0.02, 0.0, 0.0),
@@ -300,15 +300,15 @@ class TestStats(TestCase):
         (empty_returns, 0.0, np.nan),
         (one_return, 0.0, np.nan),
         (mixed_returns, mixed_returns, np.nan),
-        (mixed_returns, 0.0, 1.6368951821422701),
-        (mixed_returns, simple_benchmark, -1.3095161457138154),
+        (mixed_returns, 0.0, 1.7238613961706866),
+        (mixed_returns, simple_benchmark, -1.0343168377024115),
         (positive_returns, 0.0, 52.915026221291804),
         (negative_returns, 0.0, -24.406808633910085)
     ])
     def test_sharpe_ratio(self, returns, risk_free, expected):
         assert_almost_equal(
             empyrical.sharpe_ratio(
-                np.asarray(returns),
+                returns,
                 risk_free=risk_free),
             expected,
             DECIMAL_PLACES)
@@ -396,8 +396,8 @@ class TestStats(TestCase):
         (empty_returns, 0.0, empyrical.DAILY, np.nan),
         (one_return, 0.0, empyrical.DAILY, 0.0),
         (mixed_returns, mixed_returns, empyrical.DAILY, 0.0),
-        (mixed_returns, 0.0, empyrical.DAILY, 0.5699122739510003),
-        (mixed_returns, 0.1, empyrical.DAILY, 1.7023513150933332),
+        (mixed_returns, 0.0, empyrical.DAILY, 0.60448325038829653),
+        (mixed_returns, 0.1, empyrical.DAILY, 1.7161730681956295),
         (weekly_returns, 0.0, empyrical.WEEKLY, 0.25888650451930134),
         (weekly_returns, 0.1, empyrical.WEEKLY, 0.7733045971672482),
         (monthly_returns, 0.0, empyrical.MONTHLY, 0.1243650540411842),
@@ -481,9 +481,9 @@ class TestStats(TestCase):
         (empty_returns, 0.0, empyrical.DAILY, np.nan),
         (one_return, 0.0, empyrical.DAILY, np.nan),
         (mixed_returns, mixed_returns, empyrical.DAILY, np.nan),
-        (mixed_returns, 0.0, empyrical.DAILY, 2.456518422202588),
+        (mixed_returns, 0.0, empyrical.DAILY, 2.605531251673693),
         (mixed_returns, simple_benchmark, empyrical.DAILY,
-            -1.7457431218879385),
+            -1.3934779588919977),
         (positive_returns, 0.0, empyrical.DAILY, np.inf),
         (negative_returns, 0.0, empyrical.DAILY, -13.532743075043401),
         (simple_benchmark, 0.0, empyrical.DAILY, np.inf),
@@ -605,8 +605,8 @@ class TestStats(TestCase):
         (empty_returns, 0.0, np.nan),
         (one_return, 0.0, np.nan),
         (pos_line, pos_line, np.nan),
-        (mixed_returns, 0.0, 0.10311470414829102),
-        (mixed_returns, simple_benchmark, -0.082491763318632769),
+        (mixed_returns, 0.0, 0.10859306069076737),
+        (mixed_returns, simple_benchmark, -0.06515583641446039),
     ])
     def test_information_ratio(self, returns, factor_returns, expected):
         assert_almost_equal(
@@ -834,7 +834,7 @@ class TestStats(TestCase):
         (empty_returns, np.nan),
         (one_return, 1.0),
         (mixed_returns, 0.9473684210526313),
-        (np.random.randn(100000), 1.),
+        (pd.Series(np.random.randn(100000)), 1.),
     ])
     def test_tail_ratio(self, returns, expected):
         assert_almost_equal(

--- a/empyrical/tests/test_stats.py
+++ b/empyrical/tests/test_stats.py
@@ -817,7 +817,7 @@ class TestStats(TestCase):
     @parameterized.expand([
         (empty_returns, np.nan),
         (one_return, np.nan),
-        (mixed_returns, 0.33072113092134847),
+        (mixed_returns, 0.1529973665111273),
         (simple_benchmark, 1.0),
     ])
     def test_stability_of_timeseries(self, returns, expected):

--- a/empyrical/tests/test_stats.py
+++ b/empyrical/tests/test_stats.py
@@ -524,6 +524,8 @@ class TestStats(TestCase):
         (noise, 0),
     ])
     def test_sortino_add_noise(self, returns, required_return):
+        # Don't mutate global test state
+        returns = returns.copy()
         sr_1 = empyrical.sortino_ratio(returns, required_return)
         upside_values = returns[returns > required_return].index.tolist()
         # Add large losses at random upside locations
@@ -542,6 +544,8 @@ class TestStats(TestCase):
         (noise, 0)
     ])
     def test_sortino_sub_noise(self, returns, required_return):
+        # Don't mutate global test state
+        returns = returns.copy()
         sr_1 = empyrical.sortino_ratio(returns, required_return)
         downside_values = returns[returns < required_return].index.tolist()
         # Replace some values below the required return to the required return


### PR DESCRIPTION
@twiecki @ahgnaw Let me know what you think.

The principal goal with this is to improve performance for consumers who generally call *all* of the metrics (... such as zipline). The two meaningful changes for that aim:

1. When one calculation (e.g. `alpha`) internally depends on another calculation (e.g. `beta`),
I added a kwarg (named with a leading `_` to avoid shadowing the namespace) to allow
the consumer to pass that value in. This is optional in all cases.
2. If the risk_free rate (or the required_return) were 0, then we're wasting
time doing calculations in service of `returns - risk_free`. I initially simply
did a "if == 0" type check for this, but discovered that some empyrical functions
depended on the behavior of creating a new Series internally as they mutated that value!
For this reason, my helper method `_adjust_returns` will return a `.copy()` of the given
returns (which is faster than doing the difference).

The always-create-a-new-Series behavior from point 2 exposed that a number of the expected values in the unit tests were dependent on *other* empyrical methods or tests mutating them. The biggest problem was in `mixed_returns` which leads with a nan (presumably to evaluate the nan-tolerance of each method). Because some tests were replacing leading nan's in the input returns with 0.01, the expected values in the tests were simply wrong. Hence, changing those calculations.

Finally, while working through that, it was discovered that `sharpe_ratio`, `stability_of_timeseries` and `tail_ratio` would always return nan if there was a nan in the return streams. I made them nan-tolerant and adjusted the tests accordingly.