### PR TITLE
MAINT Beta calculation does not require explicity variance calculation.

### DIFF
--- a/empyrical/stats.py
+++ b/empyrical/stats.py
@@ -711,10 +711,11 @@ def beta(returns, factor_returns, risk_free=0.0):
     if len(joint) < 2:
         return np.nan
 
-    if np.absolute(joint.var().iloc[1]) < 1.0e-30:
+    cov = np.cov(joint.values.T, ddof=0)
+
+    if np.absolute(cov[1, 1]) < 1.0e-30:
         return np.nan
 
-    cov = np.cov(joint.values.T, ddof=0)
     return cov[0, 1] / cov[1, 1]
 
 

--- a/empyrical/stats.py
+++ b/empyrical/stats.py
@@ -714,7 +714,8 @@ def beta(returns, factor_returns, risk_free=0.0):
     if np.absolute(joint.var().iloc[1]) < 1.0e-30:
         return np.nan
 
-    return np.cov(joint.values.T, ddof=0)[0, 1] / np.var(joint.iloc[:, 1])
+    cov = np.cov(joint.values.T, ddof=0)
+    return cov[0, 1] / cov[1, 1]
 
 
 def stability_of_timeseries(returns):

--- a/empyrical/tests/test_stats.py
+++ b/empyrical/tests/test_stats.py
@@ -710,7 +710,6 @@ class TestStats(TestCase):
                 DECIMAL_PLACES
             )
 
-
     # Alpha/beta translation tests.
     @parameterized.expand([
         (0, .001),


### PR DESCRIPTION
Variance is already computed for the covariance matrix, can just use that.