### PR TITLE
Fix issue #43

### DIFF
--- a/empyrical/stats.py
+++ b/empyrical/stats.py
@@ -242,7 +242,7 @@ def max_drawdown(returns):
 
     cumulative = cum_returns(returns, starting_value=100)
     max_return = np.fmax.accumulate(cumulative)
-    return nanmin((cumulative - max_return) / max_return).min()
+    return nanmin((cumulative - max_return) / max_return).min() #Fix43
 
 
 def annual_return(returns, period=DAILY, annualization=None):

--- a/empyrical/stats.py
+++ b/empyrical/stats.py
@@ -242,7 +242,7 @@ def max_drawdown(returns):
 
     cumulative = cum_returns(returns, starting_value=100)
     max_return = np.fmax.accumulate(cumulative)
-    return nanmin((cumulative - max_return) / max_return)
+    return nanmin((cumulative - max_return) / max_return).min()
 
 
 def annual_return(returns, period=DAILY, annualization=None):


### PR DESCRIPTION
I've simply invoked a 'min()' method on object being returned from 'max_drawdown'.  Whether it is pandas.Series or numpy.ndarray, it will return float scalar. 