### PR TITLE
fix43: wrap logic in a try suite

### DIFF
--- a/empyrical/stats.py
+++ b/empyrical/stats.py
@@ -242,7 +242,12 @@ def max_drawdown(returns):
 
     cumulative = cum_returns(returns, starting_value=100)
     max_return = np.fmax.accumulate(cumulative)
-    return nanmin((cumulative - max_return) / max_return)
+    # Fix issue 43
+    try:
+        return nanmin((cumulative - max_return) / max_return).min()
+
+    except AttributeError:
+        return nanmin((cumulative - max_return) / max_return)
 
 
 def annual_return(returns, period=DAILY, annualization=None):


### PR DESCRIPTION
To handle the case  #43  where object to be returned from `max_drawdown` may be Series/ndarray, invoked 
`min` on it. If it is already a float scalar then `AttributeError` will be raised and appropriately handled. 