### PR TITLE
Fix sortino_ratio downside_risk

### DIFF
--- a/empyrical/stats.py
+++ b/empyrical/stats.py
@@ -494,7 +494,8 @@ def sortino_ratio(returns, required_return=0, period=DAILY,
     adj_returns = _adjust_returns(returns, required_return)
     mu = nanmean(adj_returns, axis=0)
     dsr = (_downside_risk if _downside_risk is not None
-           else downside_risk(returns, required_return))
+           else downside_risk(returns, required_return,
+                              period=period, annualization=annualization))
     sortino = mu / dsr
     if len(returns.shape) == 2:
         sortino = pd.Series(sortino, index=returns.columns)


### PR DESCRIPTION
This is needed because if yearly data is given, then the Sortino ratio
(sortino_ratio) can be overridden by setting the annualization value
but when downside risk is calculated in the downside_risk function it
will default to daily as annualization is not carried forward thus
affecting the final value.