### PR TITLE
Proper change to Sortino ratio to clarify the math

### DIFF
--- a/empyrical/stats.py
+++ b/empyrical/stats.py
@@ -521,8 +521,9 @@ def sortino_ratio(returns, required_return=0, period=DAILY,
     average_annual_return = nanmean(adj_returns, axis=0) * ann_factor
     annualized_downside_risk = (_downside_risk if _downside_risk is not None
                                 else downside_risk(returns, required_return,
-                                            period=period,
-                                            annualization=annualization))
+                                                   period=period,
+                                                   annualization=
+                                                   annualization))
     sortino = average_annual_return / annualized_downside_risk
     return sortino
 

--- a/empyrical/stats.py
+++ b/empyrical/stats.py
@@ -521,9 +521,7 @@ def sortino_ratio(returns, required_return=0, period=DAILY,
     average_annual_return = nanmean(adj_returns, axis=0) * ann_factor
     annualized_downside_risk = (_downside_risk if _downside_risk is not None
                                 else downside_risk(returns, required_return,
-                                                   period=period,
-                                                   annualization=
-                                                   annualization))
+                                                   period, annualization))
     sortino = average_annual_return / annualized_downside_risk
     return sortino
 

--- a/empyrical/stats.py
+++ b/empyrical/stats.py
@@ -521,8 +521,8 @@ def sortino_ratio(returns, required_return=0, period=DAILY,
     average_annual_return = nanmean(adj_returns, axis=0) * ann_factor
     annualized_downside_risk = (_downside_risk if _downside_risk is not None
                                 else downside_risk(returns, required_return,
-                                                   period=period,
-                                                   annualization=annualization))
+                                            period=period,
+                                            annualization=annualization))
     sortino = average_annual_return / annualized_downside_risk
     return sortino
 

--- a/empyrical/stats.py
+++ b/empyrical/stats.py
@@ -508,7 +508,8 @@ def sortino_ratio(returns, required_return=0, period=DAILY,
         Annualized Sortino ratio.
     Note
     -----
-    See https://www.sunrisecapital.com/wp-content/uploads/2014/06/Futures_Mag_Sortino_0213.pdf for more details.
+    See https://www.sunrisecapital.com/wp-content/uploads/2014/06/Futures_
+    Mag_Sortino_0213.pdf for more details.
     """
 
     if len(returns) < 2:
@@ -520,7 +521,8 @@ def sortino_ratio(returns, required_return=0, period=DAILY,
     average_annual_return = nanmean(adj_returns, axis=0) * ann_factor
     annualized_downside_risk = (_downside_risk if _downside_risk is not None
                                 else downside_risk(returns, required_return,
-                                                   period=period, annualization=annualization))
+                                                   period=period,
+                                                   annualization=annualization))
     sortino = average_annual_return / annualized_downside_risk
     return sortino
 
@@ -559,8 +561,9 @@ def downside_risk(returns, required_return=0, period=DAILY,
         Annualized downside deviation
     Note
     -----
-    See https://www.sunrisecapital.com/wp-content/uploads/2014/06/Futures_Mag_Sortino_0213.pdf for more details,
-    specifically why using the standard deviation of the negative returns is not correct.
+    See https://www.sunrisecapital.com/wp-content/uploads/2014/06/Futures_Mag_
+    Sortino_0213.pdf for more details, specifically why using the standard
+    deviation of the negative returns is not correct.
     """
 
     if len(returns) < 1:

--- a/empyrical/stats.py
+++ b/empyrical/stats.py
@@ -515,12 +515,12 @@ def sortino_ratio(returns, required_return=0, period=DAILY,
     ann_factor = annualization_factor(period, annualization)
 
     adj_returns = _adjust_returns(returns, required_return)
-    mu = nanmean(adj_returns, axis=0)
+    mu = nanmean(adj_returns, axis=0) * ann_factor
     dsr = (_downside_risk if _downside_risk is not None
            else downside_risk(returns, required_return,
                               period=period, annualization=annualization))
     sortino = mu / dsr
-    return sortino * ann_factor
+    return sortino
 
 
 def downside_risk(returns, required_return=0, period=DAILY,

--- a/empyrical/stats.py
+++ b/empyrical/stats.py
@@ -506,7 +506,9 @@ def sortino_ratio(returns, required_return=0, period=DAILY,
         DataFrame ==> pd.Series
 
         Annualized Sortino ratio.
-
+    Note
+    -----
+    See https://www.sunrisecapital.com/wp-content/uploads/2014/06/Futures_Mag_Sortino_0213.pdf for more details.
     """
 
     if len(returns) < 2:
@@ -515,11 +517,11 @@ def sortino_ratio(returns, required_return=0, period=DAILY,
     ann_factor = annualization_factor(period, annualization)
 
     adj_returns = _adjust_returns(returns, required_return)
-    mu = nanmean(adj_returns, axis=0) * ann_factor
-    dsr = (_downside_risk if _downside_risk is not None
-           else downside_risk(returns, required_return,
-                              period=period, annualization=annualization))
-    sortino = mu / dsr
+    average_annual_return = nanmean(adj_returns, axis=0) * ann_factor
+    annualized_downside_risk = (_downside_risk if _downside_risk is not None
+                                else downside_risk(returns, required_return,
+                                                   period=period, annualization=annualization))
+    sortino = average_annual_return / annualized_downside_risk
     return sortino
 
 
@@ -555,7 +557,10 @@ def downside_risk(returns, required_return=0, period=DAILY,
         DataFrame ==> pd.Series
 
         Annualized downside deviation
-
+    Note
+    -----
+    See https://www.sunrisecapital.com/wp-content/uploads/2014/06/Futures_Mag_Sortino_0213.pdf for more details,
+    specifically why using the standard deviation of the negative returns is not correct.
     """
 
     if len(returns) < 1:


### PR DESCRIPTION
move the annualization factor multiplication to make it more obvious that the math is correct.

This is a cosmetic change to where the annualization of the numerator returns is located. This seems to have caused confusion, see issue #61 

This PR should also replace #62 which is incorrect and should be accepted.