### PR TITLE
Docstring cleanup for cum_returns

### DIFF
--- a/empyrical/stats.py
+++ b/empyrical/stats.py
@@ -112,12 +112,7 @@ def cum_returns(returns, starting_value=0):
     pd.Series, np.ndarray, or pd.DataFrame
         Series of cumulative returns.
 
-    Note
-    ----
-    The returns parameter are simple (not logarithmic) returns which means
-    that the cumulative returns are calculated by multiplication. This
-    process has less numerical precision than using logarithmic returns
-    for which the cumulative return would be calculated by addition.
+
     """
 
     if len(returns) < 1:

--- a/empyrical/stats.py
+++ b/empyrical/stats.py
@@ -114,17 +114,11 @@ def cum_returns(returns, starting_value=0):
 
     Note
     ----
-    For increased numerical accuracy, convert input to log returns
-    where it is possible to sum instead of multiplying::
-
-      PI((1+r_i)) - 1 = exp(ln(PI(1+r_i)))     # x = exp(ln(x))
-                      = exp(SIGMA(ln(1+r_i))   # ln(a*b) = ln(a) + ln(b)
+    The returns parameter are simple (not logarithmic) returns which means
+    that the cumulative returns are calculated by multiplication. This
+    process has less numerical precision than using logarithmic returns
+    for which the cumulative return would be calculated by addition.
     """
-    # df_price.pct_change() adds a nan in first position, we can use
-    # that to have cum_logarithmic_returns start at the origin so that
-    # df_cum.iloc[0] == starting_value
-    # Note that we can't add that ourselves as we don't know which dt
-    # to use.
 
     if len(returns) < 1:
         return type(returns)([])


### PR DESCRIPTION
In response to Issue #73 the docstring for the cum_returns() function is cleaned up.