### PR TITLE
Added LICENSE to manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include versioneer.py
 include empyrical/_version.py
+include LICENSE


### PR DESCRIPTION
We should distribute the LICENSE with the source code; this is much needed for deployment on conda-forge too.