### PR TITLE
BUG: Preserve output index in `cum_returns`.

### DIFF
--- a/empyrical/stats.py
+++ b/empyrical/stats.py
@@ -37,7 +37,8 @@ def _create_unary_vectorized_roll_function(function):
         window : int
             Size of the rolling window in terms of the periodicity of the data.
         out : array-like, optional
-            The array to store the store the output.
+            Array to use as output buffer.
+            If not passed, a new array will be created.
         **kwargs
             Forwarded to :func:`~empyrical.{name}`.
 
@@ -84,7 +85,8 @@ def _create_binary_vectorized_roll_function(function):
         window : int
             Size of the rolling window in terms of the periodicity of the data.
         out : array-like, optional
-            The array to store the store the output.
+            Array to use as output buffer.
+            If not passed, a new array will be created.
         **kwargs
             Forwarded to :func:`~empyrical.{name}`.
 
@@ -203,7 +205,8 @@ def cum_returns(returns, starting_value=0, out=None):
     starting_value : float, optional
        The starting returns.
     out : array-like, optional
-        The array to store the store the output.
+        Array to use as output buffer.
+        If not passed, a new array will be created.
 
     Returns
     -------
@@ -317,7 +320,8 @@ def max_drawdown(returns, out=None):
         Daily returns of the strategy, noncumulative.
         - See full explanation in :func:`~empyrical.stats.cum_returns`.
     out : array-like, optional
-        The array to store the store the output.
+        Array to use as output buffer.
+        If not passed, a new array will be created.
 
     Returns
     -------
@@ -470,7 +474,8 @@ def annual_volatility(returns,
         returns into annual returns. Value should be the annual frequency of
         `returns`.
     out : array-like, optional
-        The array to store the store the output.
+        Array to use as output buffer.
+        If not passed, a new array will be created.
 
     Returns
     -------
@@ -634,7 +639,8 @@ def sharpe_ratio(returns,
         returns into annual returns. Value should be the annual frequency of
         `returns`.
     out : array-like, optional
-        The array to store the store the output.
+        Array to use as output buffer.
+        If not passed, a new array will be created.
 
     Returns
     -------
@@ -712,7 +718,8 @@ def sortino_ratio(returns,
         The downside risk of the given inputs, if known. Will be calculated if
         not provided.
     out : array-like, optional
-        The array to store the store the output.
+        Array to use as output buffer.
+        If not passed, a new array will be created.
 
     Returns
     -------
@@ -791,7 +798,8 @@ def downside_risk(returns,
         returns into annual returns. Value should be the annual frequency of
         `returns`.
     out : array-like, optional
-        The array to store the store the output.
+        Array to use as output buffer.
+        If not passed, a new array will be created.
 
     Returns
     -------
@@ -856,7 +864,8 @@ def excess_sharpe(returns, factor_returns, out=None):
     factor_returns: float / series
         Benchmark return to compare returns against.
     out : array-like, optional
-        The array to store the store the output.
+        Array to use as output buffer.
+        If not passed, a new array will be created.
 
     Returns
     -------
@@ -961,7 +970,8 @@ def alpha_beta(returns,
         returns into annual returns. Value should be the annual frequency of
         `returns`.
     out : array-like, optional
-        The array to store the store the output.
+        Array to use as output buffer.
+        If not passed, a new array will be created.
 
     Returns
     -------
@@ -993,7 +1003,8 @@ def roll_alpha_beta(returns, factor_returns, window=10, **kwargs):
     window : int
         Size of the rolling window in terms of the periodicity of the data.
     out : array-like, optional
-        The array to store the store the output.
+        Array to use as output buffer.
+        If not passed, a new array will be created.
     **kwargs
         Forwarded to :func:`~empyrical.alpha_beta`.
     """
@@ -1045,7 +1056,8 @@ def alpha_beta_aligned(returns,
         returns into annual returns. Value should be the annual frequency of
         `returns`.
     out : array-like, optional
-        The array to store the store the output.
+        Array to use as output buffer.
+        If not passed, a new array will be created.
 
     Returns
     -------
@@ -1113,7 +1125,8 @@ def alpha(returns,
         The beta for the given inputs, if already known. Will be calculated
         internally if not provided.
     out : array-like, optional
-        The array to store the store the output.
+        Array to use as output buffer.
+        If not passed, a new array will be created.
 
     Returns
     -------
@@ -1181,7 +1194,8 @@ def alpha_aligned(returns,
         The beta for the given inputs, if already known. Will be calculated
         internally if not provided.
     out : array-like, optional
-        The array to store the store the output.
+        Array to use as output buffer.
+        If not passed, a new array will be created.
 
     Returns
     -------
@@ -1240,7 +1254,8 @@ def beta(returns, factor_returns, risk_free=0.0, out=None):
         Constant risk-free return throughout the period. For example, the
         interest rate on a three month us treasury bill.
     out : array-like, optional
-        The array to store the store the output.
+        Array to use as output buffer.
+        If not passed, a new array will be created.
 
     Returns
     -------
@@ -1281,7 +1296,8 @@ def beta_aligned(returns, factor_returns, risk_free=0.0, out=None):
         Constant risk-free return throughout the period. For example, the
         interest rate on a three month us treasury bill.
     out : array-like, optional
-        The array to store the store the output.
+        Array to use as output buffer.
+        If not passed, a new array will be created.
 
     Returns
     -------

--- a/empyrical/stats.py
+++ b/empyrical/stats.py
@@ -58,7 +58,7 @@ def _create_unary_vectorized_roll_function(function):
             out = np.empty(0, dtype='float64')
 
         if allocated_output and isinstance(arr, pd.Series):
-            out = pd.Series(out)
+            out = pd.Series(out, index=arr.index[-len(out):])
 
         return out
 
@@ -109,9 +109,9 @@ def _create_binary_vectorized_roll_function(function):
 
         if allocated_output:
             if out.ndim == 1 and isinstance(lhs, pd.Series):
-                out = pd.Series(out)
+                out = pd.Series(out, index=lhs.index[-len(out):])
             elif out.ndim == 2 and isinstance(lhs, pd.Series):
-                out = pd.DataFrame(out)
+                out = pd.DataFrame(out, index=lhs.index[-len(out):])
         return out
 
     binary_vectorized_roll.__doc__ = binary_vectorized_roll.__doc__.format(
@@ -210,9 +210,8 @@ def cum_returns(returns, starting_value=0, out=None):
     cumulative_returns : array-like
         Series of cumulative returns.
     """
-
     if len(returns) < 1:
-        return type(returns)([])
+        return returns.copy()
 
     nanmask = np.isnan(returns)
     if np.any(nanmask):

--- a/empyrical/stats.py
+++ b/empyrical/stats.py
@@ -233,9 +233,9 @@ def cum_returns(returns, starting_value=0, out=None):
 
     if allocated_output:
         if returns.ndim == 1 and isinstance(returns, pd.Series):
-            out = pd.Series(out)
+            out = pd.Series(out, index=returns.index)
         elif isinstance(returns, pd.DataFrame):
-            out = pd.DataFrame(out)
+            out = pd.DataFrame(out, index=returns.index)
 
     return out
 

--- a/empyrical/tests/test_stats.py
+++ b/empyrical/tests/test_stats.py
@@ -13,6 +13,12 @@ from pandas.core.generic import NDFrame
 from scipy import stats
 from six import iteritems, wraps
 
+try:
+    from pandas.testing import assert_index_equal
+except ImportError:
+    # This moved in pandas 0.20.
+    from pandas.util.testing import assert_index_equal
+
 import empyrical
 import empyrical.utils as emutils
 
@@ -28,7 +34,7 @@ class BaseTestCase(TestCase):
         to be a no-op in suites like TestStatsArrays that unwrap pandas objects
         into ndarrays.
         """
-        pd.testing.assert_index_equal(result.index, expected.index)
+        assert_index_equal(result.index, expected.index)
 
 
 class TestStats(BaseTestCase):

--- a/empyrical/tests/test_stats.py
+++ b/empyrical/tests/test_stats.py
@@ -1,8 +1,8 @@
 from __future__ import division
 
-import random
 from copy import copy
 from operator import attrgetter
+import random
 from unittest import TestCase, SkipTest
 
 from parameterized import parameterized
@@ -19,7 +19,19 @@ import empyrical.utils as emutils
 DECIMAL_PLACES = 8
 
 
-class TestStats(TestCase):
+class BaseTestCase(TestCase):
+    def assert_indexes_match(self, result, expected):
+        """
+        Assert that two pandas objects have the same indices.
+
+        This is a method instead of a free function so that we can override it
+        to be a no-op in suites like TestStatsArrays that unwrap pandas objects
+        into ndarrays.
+        """
+        pd.testing.assert_index_equal(result.index, expected.index)
+
+
+class TestStats(BaseTestCase):
 
     # Simple benchmark, no drawdown
     simple_benchmark = pd.Series(
@@ -156,6 +168,8 @@ class TestStats(TestCase):
                 cum_returns[i],
                 expected[i],
                 4)
+
+        self.assert_indexes_match(cum_returns, returns)
 
     @parameterized.expand([
         (empty_returns, 0, np.nan),
@@ -996,6 +1010,8 @@ class TestStats(TestCase):
             np.asarray(expected),
             4)
 
+        self.assert_indexes_match(test, returns[-len(expected):])
+
     @parameterized.expand([
         (empty_returns, 6, []),
         (negative_returns, 6, [-18.09162052, -26.79897486, -26.69138263,
@@ -1008,6 +1024,8 @@ class TestStats(TestCase):
             np.asarray(test),
             np.asarray(expected),
             DECIMAL_PLACES)
+
+        self.assert_indexes_match(test, returns[-len(expected):])
 
     @parameterized.expand([
         (empty_returns, empty_returns, np.nan),
@@ -1057,6 +1075,7 @@ class TestStats(TestCase):
             window,
         )
         if isinstance(test, pd.DataFrame):
+            self.assert_indexes_match(test, benchmark[-len(expected):])
             test = test.values
 
         alpha_test = [t[0] for t in test]
@@ -1114,9 +1133,11 @@ class TestStats(TestCase):
             np.asarray(expected),
             DECIMAL_PLACES)
 
+        self.assert_indexes_match(test, returns[-len(expected):])
+
     @parameterized.expand([
         (empty_returns, empty_returns, 1, []),
-        (one_return, one_return, 1,  1.),
+        (one_return, one_return, 1,  [1.]),
         (mixed_returns, mixed_returns, 6, [1., 1., 1., 1.]),
         (positive_returns, mixed_returns,
          6, [0.00128406, 0.00291564, 0.00171499, 0.0777048]),
@@ -1131,6 +1152,8 @@ class TestStats(TestCase):
             np.asarray(test),
             np.asarray(expected),
             DECIMAL_PLACES)
+
+        self.assert_indexes_match(test, returns[-len(expected):])
 
     @parameterized.expand([
         (empty_returns, simple_benchmark, (np.nan, np.nan)),
@@ -1290,6 +1313,9 @@ class TestStatsArrays(TestStats):
     def empyrical(self):
         return PassArraysEmpyricalProxy(self, (np.ndarray, float))
 
+    def assert_indexes_match(self, result, expected):
+        pass
+
 
 class TestStatsIntIndex(TestStats):
     """
@@ -1308,8 +1334,11 @@ class TestStatsIntIndex(TestStats):
             lambda obj: type(obj)(obj.values, index=np.arange(len(obj))),
         )
 
+    def assert_indexes_match(self, result, expected):
+        pass
 
-class TestHelpers(TestCase):
+
+class TestHelpers(BaseTestCase):
     """
     Tests for helper methods and utils.
     """
@@ -1376,7 +1405,7 @@ class TestHelpers(TestCase):
         self.assertTrue(res.size == 0)
 
 
-class Test2DStats(TestCase):
+class Test2DStats(BaseTestCase):
     """
     Tests for functions that are capable of outputting a DataFrame.
     """
@@ -1429,6 +1458,8 @@ class Test2DStats(TestCase):
             4,
         )
 
+        self.assert_indexes_match(cum_returns, returns)
+
     @property
     def empyrical(self):
         """
@@ -1454,6 +1485,9 @@ class Test2DStatsArrays(Test2DStats):
     @property
     def empyrical(self):
         return PassArraysEmpyricalProxy(self, np.ndarray)
+
+    def assert_indexes_match(self, result, expected):
+        pass
 
 
 class ReturnTypeEmpyricalProxy(object):

--- a/empyrical/utils.py
+++ b/empyrical/utils.py
@@ -166,10 +166,13 @@ def _roll_ndarray(func, window, *args, **kwargs):
 
 def _roll_pandas(func, window, *args, **kwargs):
     data = {}
+    index_values = []
     for i in range(window, len(args[0]) + 1):
         rets = [s.iloc[i-window:i] for s in args]
-        data[args[0].index[i - 1]] = func(*rets, **kwargs)
-    return pd.Series(data)
+        index_value = args[0].index[i - 1]
+        index_values.append(index_value)
+        data[index_value] = func(*rets, **kwargs)
+    return pd.Series(data, index=type(args[0].index)(index_values))
 
 
 def cache_dir(environ=environ):


### PR DESCRIPTION
This also now makes all our rolling operations return an output indexed by a suffix of the input index.