### PR TITLE
MAINT: use int for groupby

### DIFF
--- a/empyrical/perf_attrib.py
+++ b/empyrical/perf_attrib.py
@@ -138,4 +138,4 @@ def compute_exposures(positions, factor_loadings):
             2017-01-02  0.821872  1.520515
     """
     risk_exposures = factor_loadings.multiply(positions, axis='rows')
-    return risk_exposures.groupby(level='dt').sum()
+    return risk_exposures.groupby(level=0).sum()


### PR DESCRIPTION
Instead of using the index name in the call to groupby, use the index level number.