### PR TITLE
DEP: Deprecate all data reading functionality via pandas-datareader

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ Users should beware that the following functions are now deprecated:
 - `empyrical.utils.cache_dir`
 - `empyrical.utils.data_path`
 - `empyrical.utils.ensure_directory`
-- `empyrical.utils._1_bday_ago`
 - `empyrical.utils.get_fama_french`
 - `empyrical.utils.load_portfolio_risk_factors`
 - `empyrical.utils.default_returns_func`

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ As a result, all `empyrical` support for data reading functionality has been
 deprecated and will be removed in a future version.
 
 Users should beware that the following functions are now deprecated:
+
     - `empyrical.utils.get_fama_french`
     - `empyrical.utils.load_portfolio_risk_factors`
     - `empyrical.utils.default_returns_func`
@@ -84,17 +85,21 @@ Users should beware that the following functions are now deprecated:
 
 Users should expect regular failures from the following functions, pending
 patches to the Yahoo or Google Finance API:
+
     - `empyrical.utils.default_returns_func`
     - `empyrical.utils.get_symbol_returns_from_yahoo`
 
 As an alternative data source, we suggest the following:
+
     1. Migrate your research workflow to the Quantopian Research environment,
        where there is [free and flexible data access to over 57
        datasets](https://www.quantopian.com/data)
     2. Make use of any remaining functional APIs supported by
        `pandas-datareader`. These include:
+
        - [Morningstar](https://pydata.github.io/pandas-datareader/stable/remote_data.html#remote-data-morningstar)
        - [Quandl](https://pydata.github.io/pandas-datareader/stable/remote_data.html#remote-data-quandl)
+
        Please note that you may need to create free accounts with these data
        providers and receive an API key in order to access data. These API keys
        should be set as environment variables, or passed as an argument to

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ patches to the Yahoo or Google Finance API:
 - `empyrical.utils.default_returns_func`
 - `empyrical.utils.get_symbol_returns_from_yahoo`
 
-As an alternative data source, we suggest the following:
+For alternative data sources, we suggest the following:
 
 1. Migrate your research workflow to the Quantopian Research environment,
    where there is [free and flexible data access to over 57

--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ deprecated and will be removed in a future version.
 
 Users should beware that the following functions are now deprecated:
 
+- `empyrical.utils.cache_dir`
+- `empyrical.utils.data_path`
+- `empyrical.utils.ensure_directory`
+- `empyrical.utils.get_utc_timestamp`
+- `empyrical.utils._1_bday_ago`
 - `empyrical.utils.get_fama_french`
 - `empyrical.utils.load_portfolio_risk_factors`
 - `empyrical.utils.default_returns_func`

--- a/README.md
+++ b/README.md
@@ -93,22 +93,6 @@ patches to the Yahoo or Google Finance API:
 - `empyrical.utils.default_returns_func`
 - `empyrical.utils.get_symbol_returns_from_yahoo`
 
-For alternative data sources, we suggest the following:
-
-1. Migrate your research workflow to the Quantopian Research environment,
-   where there is [free and flexible data access to over 57
-   datasets](https://www.quantopian.com/data)
-2. Make use of any remaining functional APIs supported by
-   `pandas-datareader`. These include:
-
-   - [Morningstar](https://pydata.github.io/pandas-datareader/stable/remote_data.html#remote-data-morningstar)
-   - [Quandl](https://pydata.github.io/pandas-datareader/stable/remote_data.html#remote-data-quandl)
-
-   Please note that you may need to create free accounts with these data
-   providers and receive an API key in order to access data. These API keys
-   should be set as environment variables, or passed as an argument to
-   `pandas-datareader`.
-
 ## Contributing
 
 Please contribute using [Github Flow](https://guides.github.com/introduction/flow/). Create a branch, add commits, and [open a pull request](https://github.com/quantopian/empyrical/compare/).

--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ Users should beware that the following functions are now deprecated:
 - `empyrical.utils.cache_dir`
 - `empyrical.utils.data_path`
 - `empyrical.utils.ensure_directory`
-- `empyrical.utils.get_utc_timestamp`
 - `empyrical.utils._1_bday_ago`
 - `empyrical.utils.get_fama_french`
 - `empyrical.utils.load_portfolio_risk_factors`

--- a/README.md
+++ b/README.md
@@ -63,6 +63,43 @@ roll_up_capture(returns, window=60)
 
 Please [open an issue](https://github.com/quantopian/empyrical/issues/new) for support.
 
+### Deprecated: Data Reading via `pandas-datareader`
+
+As of early 2018, Yahoo Finance has suffered major API breaks with no stable
+replacement, and the Google Finance API has not been stable since late 2017
+[(source)](https://github.com/pydata/pandas-datareader/blob/da18fbd7621d473828d7fa81dfa5e0f9516b6793/README.rst).
+In recent months it has become a greater and greater strain on the `empyrical`
+development team to maintain support for fetching data through
+`pandas-datareader` and other third-party libraries, as these APIs are known to
+be unstable.
+
+As a result, all `empyrical` support for data reading functionality has been
+deprecated and will be removed in a future version.
+
+Users should beware that the following functions are now deprecated:
+    - `empyrical.utils.get_fama_french`
+    - `empyrical.utils.load_portfolio_risk_factors`
+    - `empyrical.utils.default_returns_func`
+    - `empyrical.utils.get_symbol_returns_from_yahoo`
+
+Users should expect regular failures from the following functions, pending
+patches to the Yahoo or Google Finance API:
+    - `empyrical.utils.default_returns_func`
+    - `empyrical.utils.get_symbol_returns_from_yahoo`
+
+As an alternative data source, we suggest the following:
+    1. Migrate your research workflow to the Quantopian Research environment,
+       where there is [free and flexible data access to over 57
+       datasets](https://www.quantopian.com/data)
+    2. Make use of any remaining functional APIs supported by
+       `pandas-datareader`. These include:
+       - [Morningstar](https://pydata.github.io/pandas-datareader/stable/remote_data.html#remote-data-morningstar)
+       - [Quandl](https://pydata.github.io/pandas-datareader/stable/remote_data.html#remote-data-quandl)
+       Please note that you may need to create free accounts with these data
+       providers and receive an API key in order to access data. These API keys
+       should be set as environment variables, or passed as an argument to
+       `pandas-datareader`.
+
 ## Contributing
 
 Please contribute using [Github Flow](https://guides.github.com/introduction/flow/). Create a branch, add commits, and [open a pull request](https://github.com/quantopian/empyrical/compare/).

--- a/README.md
+++ b/README.md
@@ -78,32 +78,32 @@ deprecated and will be removed in a future version.
 
 Users should beware that the following functions are now deprecated:
 
-    - `empyrical.utils.get_fama_french`
-    - `empyrical.utils.load_portfolio_risk_factors`
-    - `empyrical.utils.default_returns_func`
-    - `empyrical.utils.get_symbol_returns_from_yahoo`
+- `empyrical.utils.get_fama_french`
+- `empyrical.utils.load_portfolio_risk_factors`
+- `empyrical.utils.default_returns_func`
+- `empyrical.utils.get_symbol_returns_from_yahoo`
 
 Users should expect regular failures from the following functions, pending
 patches to the Yahoo or Google Finance API:
 
-    - `empyrical.utils.default_returns_func`
-    - `empyrical.utils.get_symbol_returns_from_yahoo`
+- `empyrical.utils.default_returns_func`
+- `empyrical.utils.get_symbol_returns_from_yahoo`
 
 As an alternative data source, we suggest the following:
 
-    1. Migrate your research workflow to the Quantopian Research environment,
-       where there is [free and flexible data access to over 57
-       datasets](https://www.quantopian.com/data)
-    2. Make use of any remaining functional APIs supported by
-       `pandas-datareader`. These include:
+1. Migrate your research workflow to the Quantopian Research environment,
+   where there is [free and flexible data access to over 57
+   datasets](https://www.quantopian.com/data)
+2. Make use of any remaining functional APIs supported by
+   `pandas-datareader`. These include:
 
-       - [Morningstar](https://pydata.github.io/pandas-datareader/stable/remote_data.html#remote-data-morningstar)
-       - [Quandl](https://pydata.github.io/pandas-datareader/stable/remote_data.html#remote-data-quandl)
+   - [Morningstar](https://pydata.github.io/pandas-datareader/stable/remote_data.html#remote-data-morningstar)
+   - [Quandl](https://pydata.github.io/pandas-datareader/stable/remote_data.html#remote-data-quandl)
 
-       Please note that you may need to create free accounts with these data
-       providers and receive an API key in order to access data. These API keys
-       should be set as environment variables, or passed as an argument to
-       `pandas-datareader`.
+   Please note that you may need to create free accounts with these data
+   providers and receive an API key in order to access data. These API keys
+   should be set as environment variables, or passed as an argument to
+   `pandas-datareader`.
 
 ## Contributing
 

--- a/empyrical/__init__.py
+++ b/empyrical/__init__.py
@@ -55,6 +55,7 @@ from .stats import (
     roll_up_capture,
     roll_up_down_capture,
     sharpe_ratio,
+    simple_returns,
     sortino_ratio,
     stability_of_timeseries,
     tail_ratio,

--- a/empyrical/deprecate.py
+++ b/empyrical/deprecate.py
@@ -1,0 +1,45 @@
+"""Utilities for marking deprecated functions."""
+# Copyright 2018 Quantopian, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import warnings
+from functools import wraps
+
+
+def deprecated(msg=None, stacklevel=2):
+    """
+    Used to mark a function as deprecated.
+    Parameters
+    ----------
+    msg : str
+        The message to display in the deprecation warning.
+    stacklevel : int
+        How far up the stack the warning needs to go, before
+        showing the relevant calling lines.
+    Usage
+    -----
+    @deprecated(msg='function_a is deprecated! Use function_b instead.')
+    def function_a(*args, **kwargs):
+    """
+    def deprecated_dec(fn):
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            warnings.warn(
+                msg or "Function %s is deprecated." % fn.__name__,
+                category=DeprecationWarning,
+                stacklevel=stacklevel
+            )
+            return fn(*args, **kwargs)
+        return wrapper
+    return deprecated_dec

--- a/empyrical/stats.py
+++ b/empyrical/stats.py
@@ -183,6 +183,32 @@ def annualization_factor(period, annualization):
     return factor
 
 
+def simple_returns(prices):
+    """
+    Compute simple returns from a timeseries of prices.
+
+    Parameters
+    ----------
+    prices : pd.Series, pd.DataFrame or np.ndarray
+        Prices of assets in wide-format, with assets as columns,
+        and indexed by datetimes.
+
+    Returns
+    -------
+    returns : array-like
+        Returns of assets in wide-format, with assets as columns,
+        and index coerced to be tz-aware.
+    """
+    if isinstance(prices, (pd.DataFrame, pd.Series)):
+        out = prices.pct_change().iloc[1:]
+    else:
+        # Assume np.ndarray
+        out = np.diff(prices, axis=0)
+        np.divide(out, prices[:-1], out=out)
+
+    return out
+
+
 def cum_returns(returns, starting_value=0, out=None):
     """
     Compute cumulative returns from simple returns.

--- a/empyrical/tests/test_stats.py
+++ b/empyrical/tests/test_stats.py
@@ -161,6 +161,21 @@ class TestStats(BaseTestCase):
         'two': pd.Series(two, index=df_index_month)})
 
     @parameterized.expand([
+        # Constant price implies zero returns,
+        # and linearly increasing prices imples returns like 1/n
+        (flat_line_1, [0.0] * flat_line_1.shape[0]),
+        (pos_line, [np.inf] + [1/n for n in range(1, 1000)])
+    ])
+    def test_simple_returns(self, prices, expected):
+        simple_returns = self.empyrical.stats.simple_returns(prices)
+        for i in range(prices.shape[0] - 1):
+            assert_almost_equal(
+                    simple_returns[i],
+                    expected[i],
+                    4)
+        self.assert_indexes_match(simple_returns, prices.iloc[1:])
+
+    @parameterized.expand([
         (empty_returns, 0, []),
         (mixed_returns, 0, [0.0, 0.01, 0.111, 0.066559, 0.08789, 0.12052,
                             0.14293, 0.15436, 0.03893]),

--- a/empyrical/tests/test_stats.py
+++ b/empyrical/tests/test_stats.py
@@ -167,7 +167,7 @@ class TestStats(BaseTestCase):
         (pos_line, [np.inf] + [1/n for n in range(1, 1000)])
     ])
     def test_simple_returns(self, prices, expected):
-        simple_returns = self.empyrical.stats.simple_returns(prices)
+        simple_returns = self.empyrical.simple_returns(prices)
         for i in range(prices.shape[0] - 1):
             assert_almost_equal(
                     simple_returns[i],

--- a/empyrical/tests/test_stats.py
+++ b/empyrical/tests/test_stats.py
@@ -163,16 +163,12 @@ class TestStats(BaseTestCase):
     @parameterized.expand([
         # Constant price implies zero returns,
         # and linearly increasing prices imples returns like 1/n
-        (flat_line_1, [0.0] * flat_line_1.shape[0]),
-        (pos_line, [np.inf] + [1/n for n in range(1, 1000)])
+        (flat_line_1, [0.0] * (flat_line_1.shape[0] - 1)),
+        (pos_line, [np.inf] + [1/n for n in range(1, 999)])
     ])
     def test_simple_returns(self, prices, expected):
         simple_returns = self.empyrical.simple_returns(prices)
-        for i in range(prices.size - 1):
-            assert_almost_equal(
-                    simple_returns[i],
-                    expected[i],
-                    4)
+        assert_almost_equal(np.array(simple_returns), expected, 4)
         self.assert_indexes_match(simple_returns, prices.iloc[1:])
 
     @parameterized.expand([

--- a/empyrical/tests/test_stats.py
+++ b/empyrical/tests/test_stats.py
@@ -168,7 +168,7 @@ class TestStats(BaseTestCase):
     ])
     def test_simple_returns(self, prices, expected):
         simple_returns = self.empyrical.simple_returns(prices)
-        for i in range(prices.shape[0] - 1):
+        for i in range(prices.size - 1):
             assert_almost_equal(
                     simple_returns[i],
                     expected[i],

--- a/empyrical/utils.py
+++ b/empyrical/utils.py
@@ -249,7 +249,6 @@ def get_utc_timestamp(dt):
 _1_bday = BDay()
 
 
-@deprecated(msg=DATAREADER_DEPRECATION_WARNING)
 def _1_bday_ago():
     return pd.Timestamp.now().normalize() - _1_bday
 

--- a/empyrical/utils.py
+++ b/empyrical/utils.py
@@ -443,7 +443,7 @@ def get_symbol_returns_from_yahoo(symbol, start=None, end=None):
 def default_returns_func(symbol, start=None, end=None):
     """
     Gets returns for a symbol.
-    Queries Quandl Finance. Attempts to cache SPY.
+    Queries Yahoo Finance. Attempts to cache SPY.
 
     Parameters
     ----------
@@ -477,12 +477,12 @@ def default_returns_func(symbol, start=None, end=None):
                                   get_symbol_returns_from_yahoo,
                                   end,
                                   symbol='SPY',
-                                  start=start,
+                                  start='1/1/1970',
                                   end=datetime.now())
-        rets = rets[rets.index.isin(pd.bdate_range(start, end))]
+        rets = rets[start:end]
     else:
         rets = get_symbol_returns_from_yahoo(symbol, start=start, end=end)
-    rets.sort_index(inplace=True)
+
     return rets[symbol]
 
 

--- a/empyrical/utils.py
+++ b/empyrical/utils.py
@@ -268,6 +268,7 @@ def get_fama_french():
     return five_factors
 
 
+@deprecated(msg=DATAREADER_DEPRECATION_WARNING)
 def get_returns_cached(filepath, update_func, latest_dt, **kwargs):
     """
     Get returns from a cached file if the cache is recent enough,

--- a/empyrical/utils.py
+++ b/empyrical/utils.py
@@ -36,11 +36,9 @@ DATAREADER_DEPRECATION_WARNING = \
         ("Yahoo and Google Finance have suffered large API breaks with no "
          "stable replacement. As a result, any data reading functionality "
          "in empyrical has been deprecated and will be removed in a future "
-         "version."
-         "\n"
-         "Please use empyrical in the Quantopian Research environment, or "
-         "supply your own data. See README.md for more details.")
-
+         "version. See README.md for more details: "
+         "\n\n"
+         "\thttps://github.com/quantopian/pyfolio/blob/master/README.md")
 try:
     # fast versions
     import bottleneck as bn

--- a/empyrical/utils.py
+++ b/empyrical/utils.py
@@ -26,15 +26,14 @@ from pandas.tseries.offsets import BDay
 from pandas_datareader import data as web
 from .deprecate import deprecated
 
-DATALOADER_DEPRECATION_WARNING = \
-        """
-        Yahoo and Google Finance have suffered large API breaks with no stable
-        replacement. As a result, any data reading functionality in empyrical
-        has been deprecated and will be removed in a future version.
-
-        Please use empyrical in the Quantopian Research environment, or supply
-        your own data.
-        """
+DATAREADER_DEPRECATION_WARNING = \
+        ("Yahoo and Google Finance have suffered large API breaks with no "
+         "stable replacement. As a result, any data reading functionality "
+         "in empyrical has been deprecated and will be removed in a future "
+         "version."
+         ""
+         "Please use empyrical in the Quantopian Research environment, or "
+         "supply your own data. See README.md for more details.")
 
 try:
     # fast versions
@@ -245,7 +244,7 @@ def _1_bday_ago():
     return pd.Timestamp.now().normalize() - _1_bday
 
 
-@deprecated(msg=DATALOADER_DEPRECATION_WARNING)
+@deprecated(msg=DATAREADER_DEPRECATION_WARNING)
 def get_fama_french():
     """
     Retrieve Fama-French factors via pandas-datareader
@@ -336,7 +335,7 @@ def get_returns_cached(filepath, update_func, latest_dt, **kwargs):
     return returns
 
 
-@deprecated(msg=DATALOADER_DEPRECATION_WARNING)
+@deprecated(msg=DATAREADER_DEPRECATION_WARNING)
 def load_portfolio_risk_factors(filepath_prefix=None, start=None, end=None):
     """
     Load risk factors Mkt-Rf, SMB, HML, Rf, and UMD.
@@ -366,7 +365,7 @@ def load_portfolio_risk_factors(filepath_prefix=None, start=None, end=None):
     return five_factors.loc[start:end]
 
 
-@deprecated(msg=DATALOADER_DEPRECATION_WARNING)
+@deprecated(msg=DATAREADER_DEPRECATION_WARNING)
 def get_treasury_yield(start=None, end=None, period='3MO'):
     """
     Load treasury yields from FRED.
@@ -400,7 +399,7 @@ def get_treasury_yield(start=None, end=None, period='3MO'):
     return treasury
 
 
-@deprecated(msg=DATALOADER_DEPRECATION_WARNING)
+@deprecated(msg=DATAREADER_DEPRECATION_WARNING)
 def get_symbol_returns_from_yahoo(symbol, start=None, end=None):
     """
     Wrapper for pandas.io.data.get_data_yahoo().
@@ -439,7 +438,7 @@ def get_symbol_returns_from_yahoo(symbol, start=None, end=None):
     return rets
 
 
-@deprecated(msg=DATALOADER_DEPRECATION_WARNING)
+@deprecated(msg=DATAREADER_DEPRECATION_WARNING)
 def default_returns_func(symbol, start=None, end=None):
     """
     Gets returns for a symbol.

--- a/empyrical/utils.py
+++ b/empyrical/utils.py
@@ -23,7 +23,13 @@ import numpy as np
 from numpy.lib.stride_tricks import as_strided
 import pandas as pd
 from pandas.tseries.offsets import BDay
-from pandas_datareader import data as web
+try:
+    from pandas_datareader import data as web
+except ImportError as e:
+    msg = ("Unable to import pandas_datareader. Suppressing import error and "
+           "continuing. All data reading functionality will raise errors; but "
+           "has been deprecated and will be removed in a later version.")
+    warnings.warn(msg)
 from .deprecate import deprecated
 
 DATAREADER_DEPRECATION_WARNING = \
@@ -31,7 +37,7 @@ DATAREADER_DEPRECATION_WARNING = \
          "stable replacement. As a result, any data reading functionality "
          "in empyrical has been deprecated and will be removed in a future "
          "version."
-         ""
+         "\n"
          "Please use empyrical in the Quantopian Research environment, or "
          "supply your own data. See README.md for more details.")
 

--- a/empyrical/utils.py
+++ b/empyrical/utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2016 Quantopian, Inc.
+# Copyright 2018 Quantopian, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,6 +24,17 @@ from numpy.lib.stride_tricks import as_strided
 import pandas as pd
 from pandas.tseries.offsets import BDay
 from pandas_datareader import data as web
+from .deprecate import deprecated
+
+DATALOADER_DEPRECATION_WARNING = \
+        """
+        Yahoo and Google Finance have suffered large API breaks with no stable
+        replacement. As a result, any data reading functionality in empyrical
+        has been deprecated and will be removed in a future version.
+
+        Please use empyrical in the Quantopian Research environment, or supply
+        your own data.
+        """
 
 try:
     # fast versions
@@ -234,6 +245,7 @@ def _1_bday_ago():
     return pd.Timestamp.now().normalize() - _1_bday
 
 
+@deprecated(msg=DATALOADER_DEPRECATION_WARNING)
 def get_fama_french():
     """
     Retrieve Fama-French factors via pandas-datareader
@@ -324,6 +336,7 @@ def get_returns_cached(filepath, update_func, latest_dt, **kwargs):
     return returns
 
 
+@deprecated(msg=DATALOADER_DEPRECATION_WARNING)
 def load_portfolio_risk_factors(filepath_prefix=None, start=None, end=None):
     """
     Load risk factors Mkt-Rf, SMB, HML, Rf, and UMD.
@@ -353,6 +366,7 @@ def load_portfolio_risk_factors(filepath_prefix=None, start=None, end=None):
     return five_factors.loc[start:end]
 
 
+@deprecated(msg=DATALOADER_DEPRECATION_WARNING)
 def get_treasury_yield(start=None, end=None, period='3MO'):
     """
     Load treasury yields from FRED.
@@ -386,6 +400,7 @@ def get_treasury_yield(start=None, end=None, period='3MO'):
     return treasury
 
 
+@deprecated(msg=DATALOADER_DEPRECATION_WARNING)
 def get_symbol_returns_from_yahoo(symbol, start=None, end=None):
     """
     Wrapper for pandas.io.data.get_data_yahoo().
@@ -424,10 +439,11 @@ def get_symbol_returns_from_yahoo(symbol, start=None, end=None):
     return rets
 
 
+@deprecated(msg=DATALOADER_DEPRECATION_WARNING)
 def default_returns_func(symbol, start=None, end=None):
     """
     Gets returns for a symbol.
-    Queries Yahoo Finance. Attempts to cache SPY.
+    Queries Quandl Finance. Attempts to cache SPY.
 
     Parameters
     ----------
@@ -461,12 +477,12 @@ def default_returns_func(symbol, start=None, end=None):
                                   get_symbol_returns_from_yahoo,
                                   end,
                                   symbol='SPY',
-                                  start='1/1/1970',
+                                  start=start,
                                   end=datetime.now())
-        rets = rets[start:end]
+        rets = rets[rets.index.isin(pd.bdate_range(start, end))]
     else:
         rets = get_symbol_returns_from_yahoo(symbol, start=start, end=end)
-
+    rets.sort_index(inplace=True)
     return rets[symbol]
 
 

--- a/empyrical/utils.py
+++ b/empyrical/utils.py
@@ -218,14 +218,39 @@ def ensure_directory(path):
             raise
 
 
+def compute_returns(prices):
+    """
+    Computes correctly-indexed returns from prices.
+
+    Parameters
+    ----------
+    prices : pd.Series or pd.DataFrame
+        Prices of assets in wide-format, with assets as columns,
+        and indexed by datetimes.
+
+    Returns
+    -------
+    returns : pd.Series or pd.DataFrame
+        Returns of assets in wide-format, with assets as columns,
+        and index coerced to be tz-aware.
+    """
+
+    rets = prices.pct_change().dropna()
+    rets.index = rets.index.tz_localize('UTC')
+
+    return rets
+
+
 def get_utc_timestamp(dt):
     """
     Returns the Timestamp/DatetimeIndex
     with either localized or converted to UTC.
+
     Parameters
     ----------
     dt : Timestamp/DatetimeIndex
         the date(s) to be converted
+
     Returns
     -------
     same type as input

--- a/empyrical/utils.py
+++ b/empyrical/utils.py
@@ -218,7 +218,6 @@ def ensure_directory(path):
             raise
 
 
-@deprecated(msg=DATAREADER_DEPRECATION_WARNING)
 def get_utc_timestamp(dt):
     """
     Returns the Timestamp/DatetimeIndex

--- a/empyrical/utils.py
+++ b/empyrical/utils.py
@@ -222,29 +222,6 @@ def ensure_directory(path):
             raise
 
 
-def compute_returns(prices):
-    """
-    Computes correctly-indexed returns from prices.
-
-    Parameters
-    ----------
-    prices : pd.Series or pd.DataFrame
-        Prices of assets in wide-format, with assets as columns,
-        and indexed by datetimes.
-
-    Returns
-    -------
-    returns : pd.Series or pd.DataFrame
-        Returns of assets in wide-format, with assets as columns,
-        and index coerced to be tz-aware.
-    """
-
-    rets = prices.pct_change().dropna()
-    rets.index = rets.index.tz_localize('UTC')
-
-    return rets
-
-
 def get_utc_timestamp(dt):
     """
     Returns the Timestamp/DatetimeIndex

--- a/empyrical/utils.py
+++ b/empyrical/utils.py
@@ -185,6 +185,7 @@ def _roll_pandas(func, window, *args, **kwargs):
     return pd.Series(data, index=type(args[0].index)(index_values))
 
 
+@deprecated(msg=DATAREADER_DEPRECATION_WARNING)
 def cache_dir(environ=environ):
     try:
         return environ['EMPYRICAL_CACHE_DIR']
@@ -199,10 +200,12 @@ def cache_dir(environ=environ):
         )
 
 
+@deprecated(msg=DATAREADER_DEPRECATION_WARNING)
 def data_path(name):
     return join(cache_dir(), name)
 
 
+@deprecated(msg=DATAREADER_DEPRECATION_WARNING)
 def ensure_directory(path):
     """
     Ensure that a directory named "path" exists.
@@ -215,6 +218,7 @@ def ensure_directory(path):
             raise
 
 
+@deprecated(msg=DATAREADER_DEPRECATION_WARNING)
 def get_utc_timestamp(dt):
     """
     Returns the Timestamp/DatetimeIndex
@@ -240,6 +244,7 @@ def get_utc_timestamp(dt):
 _1_bday = BDay()
 
 
+@deprecated(msg=DATAREADER_DEPRECATION_WARNING)
 def _1_bday_ago():
     return pd.Timestamp.now().normalize() - _1_bday
 


### PR DESCRIPTION
Closes #96 #89 #65 #64 

Deprecates all data-fetching functionality via `pandas-datareader`, and adds a `simple_returns` helper function to replace that functionality that was implicitly done in the data-fetchers.

To quote the REAME:

As of early 2018, Yahoo Finance has suffered major API breaks with no stable replacement, and the Google Finance API has not been stable since late 2017 [(source)](https://github.com/pydata/pandas-datareader/blob/da18fbd7621d473828d7fa81dfa5e0f9516b6793/README.rst). In recent months it has become a greater and greater strain on the `empyrical` development team to maintain support for fetching data through `pandas-datareader` and other third-party libraries, as these APIs are known to be unstable.

As a result, all `empyrical` support for data reading functionality has been deprecated and will be removed in a future version.

Users should beware that the following functions are now deprecated:

- `empyrical.utils.cache_dir`
- `empyrical.utils.data_path`
- `empyrical.utils.ensure_directory`
- `empyrical.utils.get_utc_timestamp`
- `empyrical.utils._1_bday_ago`
- `empyrical.utils.get_fama_french`
- `empyrical.utils.load_portfolio_risk_factors`
- `empyrical.utils.default_returns_func`
- `empyrical.utils.get_symbol_returns_from_yahoo`

Users should expect regular failures from the following functions, pending patches to the Yahoo or Google Finance API:

- `empyrical.utils.default_returns_func`
- `empyrical.utils.get_symbol_returns_from_yahoo`