### PR TITLE
Series.as_matrix was depricated then later removed.

### DIFF
--- a/empyrical/stats.py
+++ b/empyrical/stats.py
@@ -1747,7 +1747,7 @@ Measuring Risk <https://link.springer.com/article/10.1007/s10614-006-9025-7>`
 
         DEFAULT_THRESHOLD = 0.2
         MINIMUM_THRESHOLD = 0.000000001
-        returns_array = pd.Series(returns).as_matrix()
+        returns_array = pd.Series(returns).to_numpy()
         flipped_returns = -1 * returns_array
         losses = flipped_returns[flipped_returns > 0]
         threshold = DEFAULT_THRESHOLD


### PR DESCRIPTION
Test suite was failing with pandas >= 1.0.

Test suite now passes.

Series.to_numpy() replaces Series.as_matrix().