### PR TITLE
multi-dimensional indexing is deprecated in pandas.

### DIFF
--- a/empyrical/stats.py
+++ b/empyrical/stats.py
@@ -1386,9 +1386,7 @@ def beta_aligned(returns, factor_returns, risk_free=0.0, out=None):
         returns = np.asanyarray(returns)[:, np.newaxis]
 
     if factor_returns.ndim == 1:
-        factor_returns = (factor_returns[:, np.newaxis]
-                          if isinstance(factor_returns, np.ndarray) else
-                          factor_returns.values[:, np.newaxis])
+        factor_returns = np.asanyarray(factor_returns)[:, np.newaxis]
 
     N, M = returns.shape
 

--- a/empyrical/stats.py
+++ b/empyrical/stats.py
@@ -1383,10 +1383,14 @@ def beta_aligned(returns, factor_returns, risk_free=0.0, out=None):
 
     returns_1d = returns.ndim == 1
     if returns_1d:
-        returns = returns[:, np.newaxis]
+        returns = (returns[:, np.newaxis]
+                   if isinstance(returns, np.ndarray) else
+                   returns.values[:, np.newaxis])
 
     if factor_returns.ndim == 1:
-        factor_returns = factor_returns[:, np.newaxis]
+        factor_returns = (factor_returns[:, np.newaxis]
+                          if isinstance(factor_returns, np.ndarray) else
+                          factor_returns.values[:, np.newaxis])
 
     N, M = returns.shape
 

--- a/empyrical/stats.py
+++ b/empyrical/stats.py
@@ -1383,9 +1383,7 @@ def beta_aligned(returns, factor_returns, risk_free=0.0, out=None):
 
     returns_1d = returns.ndim == 1
     if returns_1d:
-        returns = (returns[:, np.newaxis]
-                   if isinstance(returns, np.ndarray) else
-                   returns.values[:, np.newaxis])
+        returns = np.asanyarray(returns)[:, np.newaxis]
 
     if factor_returns.ndim == 1:
         factor_returns = (factor_returns[:, np.newaxis]


### PR DESCRIPTION
[Pandas is removing](https://pandas.pydata.org/pandas-docs/stable/whatsnew/v1.1.0.html#deprecations) this `[:, x]` style of multi-dimension indexer. (https://github.com/pandas-dev/pandas/issues/27837).

This converts pandas Series to an array to ensure API is compliant with updates to Pandas.